### PR TITLE
Enables support for Chrome subpixel precision

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,15 +19,16 @@
   };
 
   function getScrollbarWidth() {
-    var e = document.createElement('div');
+    var e = document.createElement('div'), rect;
     e.style.position = 'absolute';
     e.style.top = '-9999px';
     e.style.width = '100px';
-    e.style.height = '100px';
     e.style.overflow = 'scroll';
     e.style.msOverflowStyle = 'scrollbar';
     document.body.appendChild(e);
-    return (e.offsetWidth - e.clientWidth);
+    rect = e.getBoundingClientRect();
+    document.body.removeChild(e);
+    return (rect.bottom - rect.top);
   }
 
   function addClass(el, classNames) {
@@ -142,10 +143,13 @@
       return this;
     }
 
-    var heightPercentage, widthPercentage;
+    var heightPercentage, widthPercentage, rect, width, height;
 
-    this._viewElement.style.width = ((this.element.offsetWidth + SCROLLBAR_WIDTH).toString() + 'px');
-    this._viewElement.style.height = ((this.element.offsetHeight + SCROLLBAR_WIDTH).toString() + 'px');
+    rect = this.element.getBoundingClientRect();
+    width = Math.ceil(rect.right) - Math.floor(rect.left);
+    height = Math.ceil(rect.bottom) - Math.floor(rect.top);
+    this._viewElement.style.width = ((width + SCROLLBAR_WIDTH).toString() + 'px');
+    this._viewElement.style.height = ((height + SCROLLBAR_WIDTH).toString() + 'px');
 
     heightPercentage = (this._viewElement.clientHeight * 100 / this._viewElement.scrollHeight);
     widthPercentage = (this._viewElement.clientWidth * 100 / this._viewElement.scrollWidth);


### PR DESCRIPTION
- Fixes view size when container positioned with subpixel precision 
- Remove scroll width test div

When page is styled with rem units and scaled, container gets positioned at fractional coordinates while offsetWidth report rounded value. This results in 1px of scrollbar being visible http://codepen.io/anon/pen/obVyMY (Chrome 49.0.2618.8). Also for chrome getBoundingClientRect of test scroll div reports ~ 15.45px, while current test method reports 15px