### PR TITLE
fix autoshow functionality whilst dragging thumb of a scrollbar

### DIFF
--- a/gemini-scrollbar.css
+++ b/gemini-scrollbar.css
@@ -85,6 +85,7 @@
   transition: opacity 120ms ease-out;
 }
 .gm-scrollbar-container.gm-autoshow:hover .gm-scrollbar,
+.gm-scrollbar-container.gm-autoshow:active .gm-scrollbar {
 .gm-scrollbar-container.gm-autoshow:focus .gm-scrollbar {
   opacity: 1;
   transition: opacity 340ms ease-out;


### PR DESCRIPTION
this fix will make sure that in autoshow mode,  it'll keep showing scrollbar if user moves cursor out of scrollview area horizontally whilst dragging thumb vertically.
