### PR TITLE
Add an option to turn off relayouts on update

### DIFF
--- a/index.js
+++ b/index.js
@@ -65,7 +65,6 @@
     this.createElements = true;
     this.forceGemini = false;
     this.onResize = null;
-    this.relayoutOnUpdate = true;
 
     Object.keys(config || {}).forEach(function (propertyName) {
       this[propertyName] = config[propertyName];
@@ -213,19 +212,6 @@
     }
 
     var heightPercentage, widthPercentage;
-
-    if (this.relayoutOnUpdate) {
-      // I'm not sure what the purpose of this is - it was introduced here, but
-      // there isn't much clue as to why it is necessary:
-      // https://github.com/noeldelgado/gemini-scrollbar/commit/3b5674c
-      //
-      // The problem is that the two complete re-layouts which result from this
-      // can be quite expensive on complex layouts; so it can be disabled by
-      // setting relayoutOnUpdate = false.
-
-      this._viewElement.style.width = '';
-      this._viewElement.style.height = '';
-    }
 
     this._viewElement.style.width = ((this.element.offsetWidth + SCROLLBAR_WIDTH).toString() + 'px');
     this._viewElement.style.height = ((this.element.offsetHeight + SCROLLBAR_WIDTH).toString() + 'px');

--- a/index.js
+++ b/index.js
@@ -55,6 +55,7 @@
     this.autoshow = false;
     this.createElements = true;
     this.forceGemini = false;
+    this.relayoutOnUpdate = true;
 
     Object.keys(config || {}).forEach(function (propertyName) {
       this[propertyName] = config[propertyName];
@@ -145,8 +146,19 @@
     }
 
     var heightPercentage, widthPercentage;
-    this._viewElement.style.width = '';
-    this._viewElement.style.height = '';
+
+    if (this.relayoutOnUpdate) {
+      // I'm not sure what the purpose of this is - it was introduced here, but
+      // there isn't much clue as to why it is necessary:
+      // https://github.com/noeldelgado/gemini-scrollbar/commit/3b5674c
+      //
+      // The problem is that the two complete re-layouts which result from this
+      // can be quite expensive on complex layouts; so it can be disabled by
+      // setting relayoutOnUpdate = false.
+
+      this._viewElement.style.width = '';
+      this._viewElement.style.height = '';
+    }
 
     this._viewElement.style.width = ((this.element.offsetWidth + SCROLLBAR_WIDTH).toString() + 'px');
     this._viewElement.style.height = ((this.element.offsetHeight + SCROLLBAR_WIDTH).toString() + 'px');


### PR DESCRIPTION
@noeldelgado, I would be interested to know what you think of this.

We did some profiling and found that updating the contents of the scrolling div was quite expensive, because resetting the viewElement width made the browser reflow the entire DOM, which was often unnecessary.

Do you know the purpose of resetting `this._viewElement.style.width`? As you can see, I made it optional (and exposed this via the react wrapper); we've had it disabled in our application for some time now with no apparent ill-effects. 