### PR TITLE
remove / separeted _viewElement

### DIFF
--- a/examples/04-random-tests.html
+++ b/examples/04-random-tests.html
@@ -241,7 +241,10 @@
     }).create()
 
     var ex7 = new GeminiScrollbar({
-        element: document.querySelector('#example-7')
+        element: document.querySelector('#example-7'),
+        onResize: function() {
+          console.log(this.getViewElement());
+        }
     }).create()
   }
 </script>

--- a/index.js
+++ b/index.js
@@ -92,19 +92,6 @@
       addClass(this.element, [CLASSNAMES.prevented]);
 
       if (this.onResize) {
-        // still need a resize trigger if we have an onResize callback, which
-        // also means we need a separate _viewElement to do the scrolling.
-        if (this.createElements === true) {
-          this._viewElement = document.createElement('div');
-          while(this.element.childNodes.length > 0) {
-            this._viewElement.appendChild(this.element.childNodes[0]);
-          }
-          this.element.appendChild(this._viewElement);
-        } else {
-          this._viewElement = this.element.querySelector('.' + CLASSNAMES.view);
-        }
-        addClass(this.element, [CLASSNAMES.element]);
-        addClass(this._viewElement, [CLASSNAMES.view]);
         this._createResizeTrigger();
       }
 


### PR DESCRIPTION
When native scrollbars are supported and an `onResize` callback is passed, we need to create the resize trigger object for the event to be fired but we do not need to create a separeted `_viewElement`.

The way gemini works is that it will use the native scrollbars if the OS supports “overlay-scrollbars” (which means that the `element` you pass on the configuration should be scrollable by default `overflow: auto|scroll`).