### PR TITLE
Escaped asterisk in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Or, you can add the relevant files in your document.
 
 name | type | default | description
 |:--- | :--- | :--- | :---
-* **element** | HTMLElement | `null` | The element to apply scrollbars
+**element &ast;** | HTMLElement | `null` | The element to apply scrollbars
 autoshow | Boolean | `false` | Show scrollbars upon hovering
 createElements | Boolean | `true` | Create and append the require HTMLElements at runtime.
 forceGemini | Boolean | `false` | Force Gemini scrollbars even if native overlay-scrollbars are available. Useful for development.


### PR DESCRIPTION
Fixed an unescaped asterisk that broke the table styling for configuration options.