### PR TITLE
Prevent losing keyboard focus in object

### DIFF
--- a/index.js
+++ b/index.js
@@ -181,6 +181,7 @@
     var obj = document.createElement('object');
     addClass(obj, [CLASSNAMES.resizeTrigger]);
     obj.type = 'text/html';
+    obj.setAttribute('tabindex', '-1');
     var resizeHandler = this._resizeHandler.bind(this);
     obj.onload = function () {
       var win = obj.contentDocument.defaultView;


### PR DESCRIPTION
Adding tabindex="-1" to the `object` element prevents keyboard users from losing focus when trying to exit the scrollbar node.